### PR TITLE
Add reverse proxy for BeBraven.org application.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -58,6 +58,16 @@ http {
   }
 
   server {
+    server_name bravenweb;
+    listen 80;
+
+    location / {
+      proxy_pass http://bravenweb:3007;
+      rewrite ^/bravenweb(.*)$ $1 break;
+    }
+  }
+
+  server {
     server_name platformweb;
     listen 80;
 


### PR DESCRIPTION
Test Plan:
- Build the braven_2 docker containers.
- Run a dbrefresh so they are up.
- Make sure it works on http://localhost:3007
- Add bravenweb to /etc/hosts
- Make sure http://bravenweb works with this nginx container running.