### PR TITLE
Fix platformweb https login

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -77,6 +77,8 @@ http {
     location / {
       proxy_pass http://platformweb:3020;
       rewrite ^/platformweb(.*)$ $1 break;
+      proxy_set_header  Host $host;
+      proxy_set_header  X-Forwarded-Proto $scheme;
     }
   }
 }


### PR DESCRIPTION
Was giving an InvalidAuthenticityToken error when trying to log in via https. Now fixed.

Ref: https://github.com/rails/rails/issues/22965#issuecomment-642549585