### PR TITLE
Make platformweb work using ngrok and boosterplatformweb.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ openssl req \
 
 2. Check the .crt and .key into src control.
 
-3. Then on a Mac open up Keychain Access app, click on Certificates on the left, drag your new `platformweb-selfsigned.crt` into there, double click it, expand the Trust section, change the setting to *"When using this certificate" : "Always Trust"*, close and type your computer password to save. 
+3. Update docker-compose.yml to map your new .crt and .key into the docker image as a volume. See the platformweb example in there.
 
-4. Update the `nginx.conf` to liston on port 443 and use your new self-signed key which you've told your local computer to trust. Just look at the platformweb config in there for an example
+4. Then on a Mac open up Keychain Access app, click on Certificates on the left, drag your new `platformweb-selfsigned.crt` into there, double click it, expand the Trust section, change the setting to *"When using this certificate" : "Always Trust"*, close and type your computer password to save. 
+
+5. Update the `nginx.conf` to liston on port 443 and use your new self-signed key which you've told your local computer to trust. Just look at the platformweb config in there for an example
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -77,7 +77,19 @@ http {
     location / {
       proxy_pass http://platformweb:3020;
       rewrite ^/platformweb(.*)$ $1 break;
-      proxy_set_header  Host $host;
+      proxy_set_header  Host platformweb;
+      proxy_set_header  X-Forwarded-Proto $scheme;
+    }
+  }
+
+  server {
+    server_name boosterplatformweb;
+    listen 80;
+
+    location / {
+      proxy_pass http://boosterplatformweb:3020;
+      rewrite ^/boosterplatformweb(.*)$ $1 break;
+      proxy_set_header  Host boosterplatformweb;
       proxy_set_header  X-Forwarded-Proto $scheme;
     }
   }


### PR DESCRIPTION
When developing the LTI extension, the Host will be canvas or ngrok.
Hard-code the Host header when proxying requests so that the destination
app doesn't know about all that and just sees the request coming from either platformweb or
boosterplatformweb. This is so that we don't have to add new things to `config.hosts` in
`config/environments/development.rb` on the platformweb server.